### PR TITLE
fix: label is too large

### DIFF
--- a/.run/Run IDE with Plugin.run.xml
+++ b/.run/Run IDE with Plugin.run.xml
@@ -11,7 +11,7 @@
             </option>
             <option name="taskNames">
                 <list>
-                    <option value="runIde"/>
+                    <option value="runIdeForUITests"/>
                 </list>
             </option>
             <option name="vmOptions" value=""/>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 # Project Label Changelog
 
 ## [Unreleased]
+### Fixed
+- Label is too big in the new UI
+- Larger font size in the old UI
 
 ## [1.1.0] - 2023-04-06
 

--- a/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelStatusBarWidget.java
+++ b/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelStatusBarWidget.java
@@ -34,6 +34,7 @@ public class ProjectLabelStatusBarWidget extends JButton implements CustomStatus
 
     private static final int HORIZONTAL_PADDING = 18;
     private static final int VERTICAL_PADDING = 2;
+    private static final int VERTICAL_MARGIN = 5;
     private static final int HEIGHT = 12;
 
     private final Project project;
@@ -166,21 +167,20 @@ public class ProjectLabelStatusBarWidget extends JButton implements CustomStatus
             Dimension size = getSize();
             final Dimension arcs = new Dimension(8, 8);
 
-            // image
-            bufferedImage = ImageUtil.createImage(size.width, size.height, BufferedImage.TYPE_INT_ARGB);
+            FontMetrics metrics = graphics.getFontMetrics(font);
+
+            bufferedImage = ImageUtil.createImage(size.width, size.height - VERTICAL_MARGIN, BufferedImage.TYPE_INT_ARGB);
             Graphics2D graphics2D = (Graphics2D) bufferedImage.getGraphics().create();
 
             graphics2D.setRenderingHints(HINTS);
 
             // background
             graphics2D.setColor(backgroundColor);
-            graphics2D.fillRoundRect(0, 0, size.width, size.height, arcs.width, arcs.height);
+            graphics2D.fillRoundRect(0, VERTICAL_MARGIN, size.width, size.height - (2 * VERTICAL_MARGIN), arcs.width, arcs.height);
 
             // label
             graphics2D.setColor(textColor);
             graphics2D.setFont(font);
-
-            FontMetrics metrics = graphics.getFontMetrics(font);
 
             graphics2D.drawString(
                     label,

--- a/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelStatusBarWidget.java
+++ b/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelStatusBarWidget.java
@@ -3,10 +3,10 @@ package com.drinchev.projectlabel.resources.ui;
 import com.drinchev.projectlabel.preferences.ApplicationPreferences;
 import com.drinchev.projectlabel.preferences.ProjectPreferences;
 import com.drinchev.projectlabel.utils.UtilsFont;
+import com.drinchev.projectlabel.utils.UtilsUI;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.options.ShowSettingsUtil;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.wm.CustomStatusBarWidget;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.ui.JBColor;
@@ -35,7 +35,7 @@ public class ProjectLabelStatusBarWidget extends JButton implements CustomStatus
 
     private static final int HORIZONTAL_PADDING = 18;
     private static final int VERTICAL_PADDING = 2;
-    private static final int VERTICAL_MARGIN = Registry.is("ide.experimental.ui") ? 5 : 3;
+    private static final int VERTICAL_MARGIN = UtilsUI.isNewUI() ? 5 : 3;
     private static final int HEIGHT = 12;
 
     private final Project project;
@@ -167,17 +167,18 @@ public class ProjectLabelStatusBarWidget extends JButton implements CustomStatus
 
             Dimension size = getSize();
             final Dimension arcs = new Dimension(8, 8);
+            int height = size.height - (2 * VERTICAL_MARGIN);
 
             FontMetrics metrics = graphics.getFontMetrics(font);
 
-            bufferedImage = ImageUtil.createImage(size.width, size.height - VERTICAL_MARGIN, BufferedImage.TYPE_INT_ARGB);
+            bufferedImage = ImageUtil.createImage(size.width, height, BufferedImage.TYPE_INT_ARGB);
             Graphics2D graphics2D = (Graphics2D) bufferedImage.getGraphics().create();
 
             graphics2D.setRenderingHints(HINTS);
 
             // background
             graphics2D.setColor(backgroundColor);
-            graphics2D.fillRoundRect(0, VERTICAL_MARGIN, size.width, size.height - (2 * VERTICAL_MARGIN), arcs.width, arcs.height);
+            graphics2D.fillRoundRect(0, 0, size.width, height, arcs.width, arcs.height);
 
             // label
             graphics2D.setColor(textColor);
@@ -186,12 +187,12 @@ public class ProjectLabelStatusBarWidget extends JButton implements CustomStatus
             graphics2D.drawString(
                     label,
                     (size.width - labelWidth) / 2,
-                    (size.height - metrics.getHeight()) / 2 + metrics.getAscent()
+                    (height - metrics.getHeight()) / 2 + metrics.getAscent()
             );
             graphics2D.dispose();
         }
 
-        UIUtil.drawImage(graphics, bufferedImage, 0, 0, null);
+        UIUtil.drawImage(graphics, bufferedImage, 0, VERTICAL_MARGIN, null);
     }
 
     @Override

--- a/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelStatusBarWidget.java
+++ b/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelStatusBarWidget.java
@@ -6,6 +6,7 @@ import com.drinchev.projectlabel.utils.UtilsFont;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.options.ShowSettingsUtil;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.openapi.wm.CustomStatusBarWidget;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.ui.JBColor;
@@ -34,7 +35,7 @@ public class ProjectLabelStatusBarWidget extends JButton implements CustomStatus
 
     private static final int HORIZONTAL_PADDING = 18;
     private static final int VERTICAL_PADDING = 2;
-    private static final int VERTICAL_MARGIN = 5;
+    private static final int VERTICAL_MARGIN = Registry.is("ide.experimental.ui") ? 5 : 3;
     private static final int HEIGHT = 12;
 
     private final Project project;

--- a/src/main/java/com/drinchev/projectlabel/utils/UtilsFont.java
+++ b/src/main/java/com/drinchev/projectlabel/utils/UtilsFont.java
@@ -1,6 +1,5 @@
 package com.drinchev.projectlabel.utils;
 
-import com.intellij.openapi.util.registry.Registry;
 import com.intellij.util.ui.JBFont;
 
 import java.awt.*;
@@ -45,7 +44,7 @@ public class UtilsFont {
         try {
             // while the new UI is experimental, we have to carefully choose the font size
             if (JBFont.class.getDeclaredMethod("smallOrNewUiMedium") != null) {
-                return Registry.is("ide.experimental.ui") ? JBFont.medium() : JBFont.small();
+                return UtilsUI.isNewUI() ? JBFont.medium() : JBFont.small();
             }
         } catch (NoSuchMethodException e) {
             return JBFont.medium();

--- a/src/main/java/com/drinchev/projectlabel/utils/UtilsFont.java
+++ b/src/main/java/com/drinchev/projectlabel/utils/UtilsFont.java
@@ -1,5 +1,6 @@
 package com.drinchev.projectlabel.utils;
 
+import com.intellij.openapi.util.registry.Registry;
 import com.intellij.util.ui.JBFont;
 
 import java.awt.*;
@@ -41,7 +42,15 @@ public class UtilsFont {
     }
 
     public static JBFont getStatusBarItemFont() {
-        return JBFont.medium();
+        try {
+            // while the new UI is experimental, we have to carefully choose the font size
+            if (JBFont.class.getDeclaredMethod("smallOrNewUiMedium") != null) {
+                return Registry.is("ide.experimental.ui") ? JBFont.medium() : JBFont.small();
+            }
+        } catch (NoSuchMethodException e) {
+            return JBFont.medium();
+        }
+        throw new IllegalStateException("Unable to determine the status bar font size");
     }
 
 }

--- a/src/main/java/com/drinchev/projectlabel/utils/UtilsUI.java
+++ b/src/main/java/com/drinchev/projectlabel/utils/UtilsUI.java
@@ -1,0 +1,11 @@
+package com.drinchev.projectlabel.utils;
+
+import com.intellij.openapi.util.registry.Registry;
+
+public class UtilsUI {
+
+    public static Boolean isNewUI() {
+        return Registry.is("ide.experimental.ui");
+    }
+
+}


### PR DESCRIPTION
The label is too large in the new UI.

![image](https://user-images.githubusercontent.com/202919/230492137-9e0fe72d-7ce5-4d87-8767-296e7dd4e2fa.png)

Testing this locally with `runIde` is not giving the same as the gradle task `runIdeForUITests`.

This PR is still not finished though. On the "old" ( classic? ) UI the label appears quite small due to the new `VERTICAL_MARGIN`.

What I'm currently trying to figure out is **if there's a way to detect New UI vs Classic**.


