### PR TITLE
feat: add code formatting and checking

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ on:
 jobs:
 
   # Run Gradle Wrapper Validation Action to verify the wrapper's checksum
+  # Run spotlessCheck task to validate code style
   # Run verifyPlugin, IntelliJ Plugin Verifier, and test Gradle tasks
   # Build plugin and provide the artifact for the next workflow jobs
   build:
@@ -47,12 +48,16 @@ jobs:
       - name: Gradle Wrapper Validation
         uses: gradle/wrapper-validation-action@v1.0.6
 
-      # Setup Java 11 environment for the next steps
+      # Setup Java 17 environment for the next steps
       - name: Setup Java
         uses: actions/setup-java@v3
         with:
           distribution: zulu
           java-version: 17
+
+      # Validate Code Style
+      - name: Validate Code Style
+        run: ./gradlew spotlessCheck
 
       # Set environment variables
       - name: Export Properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("java")
     id("org.jetbrains.intellij") version "1.13.3"
     id("org.jetbrains.changelog") version "2.0.0"
+    id("com.diffplug.spotless") version "6.18.0"
 }
 
 group = properties("pluginGroup").get()
@@ -32,6 +33,14 @@ intellij {
 changelog {
     groups.empty()
     repositoryUrl.set(properties("pluginRepositoryUrl"))
+}
+
+spotless {
+    java {
+        importOrder()
+        removeUnusedImports()
+        palantirJavaFormat()
+    }
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.diffplug.spotless.LineEnding
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
 
@@ -35,11 +36,17 @@ changelog {
     repositoryUrl.set(properties("pluginRepositoryUrl"))
 }
 
+// Configure code style -- apply with `./gradlew spotlessApply`, check with `./gradlew spotlessCheck`
 spotless {
+
+    lineEndings = LineEnding.UNIX
+    encoding = Charsets.UTF_8
+
     java {
         importOrder()
         removeUnusedImports()
         palantirJavaFormat()
+        endWithNewline()
     }
 }
 

--- a/src/main/java/com/drinchev/projectlabel/ProjectLabel.java
+++ b/src/main/java/com/drinchev/projectlabel/ProjectLabel.java
@@ -1,5 +1,6 @@
 package com.drinchev.projectlabel;
 
+import static java.util.Objects.requireNonNull;
 
 import com.drinchev.projectlabel.resources.ui.ProjectLabelBackgroundImage;
 import com.drinchev.projectlabel.resources.ui.ProjectLabelStatusBarWidget;
@@ -9,9 +10,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.WindowManager;
 import org.jetbrains.annotations.NotNull;
-
-
-import static java.util.Objects.requireNonNull;
 
 @Service(Level.PROJECT)
 public class ProjectLabel {
@@ -29,7 +27,8 @@ public class ProjectLabel {
 
     private void updateStatusBar() {
         StatusBar statusBar = WindowManager.getInstance().getStatusBar(project);
-        ProjectLabelStatusBarWidget statusBarWidget = (ProjectLabelStatusBarWidget) statusBar.getWidget(ProjectLabelStatusBarWidget.WIDGET_ID);
+        ProjectLabelStatusBarWidget statusBarWidget =
+                (ProjectLabelStatusBarWidget) statusBar.getWidget(ProjectLabelStatusBarWidget.WIDGET_ID);
         if (statusBarWidget != null) {
             statusBarWidget.rebuildWidget();
             statusBarWidget.updateUI();

--- a/src/main/java/com/drinchev/projectlabel/ProjectLabelConfigurable.java
+++ b/src/main/java/com/drinchev/projectlabel/ProjectLabelConfigurable.java
@@ -1,26 +1,23 @@
 package com.drinchev.projectlabel;
 
-import javax.swing.*;
-
 import com.drinchev.projectlabel.preferences.ApplicationPreferences;
 import com.drinchev.projectlabel.preferences.BackgroundImagePrefs;
 import com.drinchev.projectlabel.preferences.ProjectPreferences;
 import com.drinchev.projectlabel.resources.ui.BackgroundImagePosition;
 import com.drinchev.projectlabel.resources.ui.PluginConfiguration;
-
 import com.drinchev.projectlabel.utils.UtilsColor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.options.Configurable;
+import com.intellij.openapi.project.Project;
+import java.util.Objects;
+import javax.swing.*;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import com.intellij.openapi.project.Project;
-
-import java.util.Objects;
 
 public class ProjectLabelConfigurable implements Configurable {
 
-    private final static Logger LOG = Logger.getInstance(ProjectLabelConfigurable.class);
+    private static final Logger LOG = Logger.getInstance(ProjectLabelConfigurable.class);
 
     private PluginConfiguration preferencesPanel;
 
@@ -61,33 +58,36 @@ public class ProjectLabelConfigurable implements Configurable {
         preferencesPanel.setFontName(projectPreferences.getFontName());
         preferencesPanel.setLabel(projectPreferences.getLabel());
         preferencesPanel.setBackgroundImagePrefs(
-                projectPreferences.isBackgroundImageInherited() ? null : new BackgroundImagePrefs(
-                        projectPreferences.getBackgroundImageOpacity(),
-                        projectPreferences.getBackgroundImagePosition()
-                ),
+                projectPreferences.isBackgroundImageInherited()
+                        ? null
+                        : new BackgroundImagePrefs(
+                                projectPreferences.getBackgroundImageOpacity(),
+                                projectPreferences.getBackgroundImagePosition()),
                 new BackgroundImagePrefs(
                         applicationPreferences.getBackgroundImageOpacity(),
-                        applicationPreferences.getBackgroundImagePosition()
-                )
-        );
+                        applicationPreferences.getBackgroundImagePosition()));
         preferencesPanel.initStates();
     }
 
     public boolean isModified() {
-        return !UtilsColor.isEqual(projectPreferences.getBackgroundColor(), preferencesPanel.getBackgroundColor()) ||
-                !UtilsColor.isEqual(projectPreferences.getTextColor(), preferencesPanel.getTextColor()) ||
-                projectPreferences.getFontSize() != preferencesPanel.getFontSize() ||
-                !projectPreferences.getLabel().equals(preferencesPanel.getLabel()) ||
-                !projectPreferences.getFontName().equals(preferencesPanel.getFontName()) ||
-                applicationPreferences.getFontSize() != preferencesPanel.getGlobalFontSize() ||
-                !applicationPreferences.getFontName().equals(preferencesPanel.getGlobalFontName()) ||
-                !Objects.equals(
-                        BackgroundImagePrefs.from(projectPreferences.isBackgroundImageInherited(), projectPreferences.getBackgroundImageOpacity(), projectPreferences.getBackgroundImagePosition()),
-                        preferencesPanel.getBackgroundImagePrefs()) ||
-                !Objects.equals(
-                        BackgroundImagePrefs.from(applicationPreferences.getBackgroundImageOpacity(), applicationPreferences.getBackgroundImagePosition()),
-                        preferencesPanel.getGlobalBackgroundImagePrefs()
-                );
+        return !UtilsColor.isEqual(projectPreferences.getBackgroundColor(), preferencesPanel.getBackgroundColor())
+                || !UtilsColor.isEqual(projectPreferences.getTextColor(), preferencesPanel.getTextColor())
+                || projectPreferences.getFontSize() != preferencesPanel.getFontSize()
+                || !projectPreferences.getLabel().equals(preferencesPanel.getLabel())
+                || !projectPreferences.getFontName().equals(preferencesPanel.getFontName())
+                || applicationPreferences.getFontSize() != preferencesPanel.getGlobalFontSize()
+                || !applicationPreferences.getFontName().equals(preferencesPanel.getGlobalFontName())
+                || !Objects.equals(
+                        BackgroundImagePrefs.from(
+                                projectPreferences.isBackgroundImageInherited(),
+                                projectPreferences.getBackgroundImageOpacity(),
+                                projectPreferences.getBackgroundImagePosition()),
+                        preferencesPanel.getBackgroundImagePrefs())
+                || !Objects.equals(
+                        BackgroundImagePrefs.from(
+                                applicationPreferences.getBackgroundImageOpacity(),
+                                applicationPreferences.getBackgroundImagePosition()),
+                        preferencesPanel.getGlobalBackgroundImagePrefs());
     }
 
     public void apply() {

--- a/src/main/java/com/drinchev/projectlabel/ProjectLabelStartupActivity.java
+++ b/src/main/java/com/drinchev/projectlabel/ProjectLabelStartupActivity.java
@@ -1,13 +1,12 @@
 package com.drinchev.projectlabel;
 
+import com.drinchev.projectlabel.resources.ui.ProjectLabelBackgroundImage;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.ProjectPostStartupActivity;
 import kotlin.Unit;
 import kotlin.coroutines.Continuation;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import com.drinchev.projectlabel.resources.ui.ProjectLabelBackgroundImage;
 
 public class ProjectLabelStartupActivity implements ProjectPostStartupActivity {
 

--- a/src/main/java/com/drinchev/projectlabel/ProjectLabelWidgetFactory.java
+++ b/src/main/java/com/drinchev/projectlabel/ProjectLabelWidgetFactory.java
@@ -15,14 +15,12 @@ import org.jetbrains.annotations.NotNull;
 
 public class ProjectLabelWidgetFactory implements StatusBarWidgetFactory {
     @Override
-    public @NotNull
-    @NonNls String getId() {
+    public @NotNull @NonNls String getId() {
         return ProjectLabelStatusBarWidget.WIDGET_ID;
     }
 
     @Override
-    public @NotNull
-    @NlsContexts.ConfigurableName String getDisplayName() {
+    public @NotNull @NlsContexts.ConfigurableName String getDisplayName() {
         return "Project Label";
     }
 
@@ -35,7 +33,8 @@ public class ProjectLabelWidgetFactory implements StatusBarWidgetFactory {
     public @NotNull StatusBarWidget createWidget(@NotNull Project project) {
         ProjectPreferences projectPreferences = ProjectPreferences.getInstance(project);
         ApplicationPreferences applicationPreferences = ApplicationPreferences.getInstance();
-        return new ProjectLabelStatusBarWidget(project, new PreferencesReader(project, projectPreferences, applicationPreferences));
+        return new ProjectLabelStatusBarWidget(
+                project, new PreferencesReader(project, projectPreferences, applicationPreferences));
     }
 
     @Override

--- a/src/main/java/com/drinchev/projectlabel/preferences/ApplicationPreferences.java
+++ b/src/main/java/com/drinchev/projectlabel/preferences/ApplicationPreferences.java
@@ -8,22 +8,19 @@ import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import com.intellij.util.xmlb.annotations.OptionTag;
+import java.awt.*;
+import java.util.Objects;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.awt.*;
-import java.util.Objects;
-
 @State(
         name = "ProjectLabelApplicationPreferences",
-        storages = {
-                @Storage("project-label-global.xml")
-        }
-)
+        storages = {@Storage("project-label-global.xml")})
 public class ApplicationPreferences implements PersistentStateComponent<ApplicationPreferences> {
 
     @OptionTag
-    private String fontSize = String.valueOf(UtilsFont.getStatusBarItemFont().getSize()); // https://jetbrains.design/intellij/principles/typography/#03
+    private String fontSize = String.valueOf(
+            UtilsFont.getStatusBarItemFont().getSize()); // https://jetbrains.design/intellij/principles/typography/#03
 
     @OptionTag
     private String fontName = UtilsFont.getStatusBarItemFont().getFontName();
@@ -70,7 +67,8 @@ public class ApplicationPreferences implements PersistentStateComponent<Applicat
     }
 
     public void setBackgroundImagePosition(@NotNull BackgroundImagePosition backgroundImagePosition) {
-        this.backgroundImagePosition = Objects.requireNonNull(backgroundImagePosition).name();
+        this.backgroundImagePosition =
+                Objects.requireNonNull(backgroundImagePosition).name();
     }
 
     public BackgroundImagePosition getBackgroundImagePosition() {
@@ -84,5 +82,4 @@ public class ApplicationPreferences implements PersistentStateComponent<Applicat
     public void setBackgroundImageOpacity(int backgroundImageOpacity) {
         this.backgroundImageOpacity = backgroundImageOpacity;
     }
-
 }

--- a/src/main/java/com/drinchev/projectlabel/preferences/BackgroundImagePrefs.java
+++ b/src/main/java/com/drinchev/projectlabel/preferences/BackgroundImagePrefs.java
@@ -4,7 +4,8 @@ import com.drinchev.projectlabel.resources.ui.BackgroundImagePosition;
 
 public record BackgroundImagePrefs(int opacity, BackgroundImagePosition position) {
 
-    public static BackgroundImagePrefs from(boolean inherited, int opacity, BackgroundImagePosition backgroundPosition) {
+    public static BackgroundImagePrefs from(
+            boolean inherited, int opacity, BackgroundImagePosition backgroundPosition) {
         return inherited ? null : new BackgroundImagePrefs(opacity, backgroundPosition);
     }
 

--- a/src/main/java/com/drinchev/projectlabel/preferences/PreferencesReader.java
+++ b/src/main/java/com/drinchev/projectlabel/preferences/PreferencesReader.java
@@ -1,13 +1,12 @@
 package com.drinchev.projectlabel.preferences;
 
+import static java.util.Objects.requireNonNull;
+
 import com.drinchev.projectlabel.resources.ui.BackgroundImagePosition;
 import com.drinchev.projectlabel.utils.UtilsFont;
 import com.intellij.openapi.project.Project;
-import org.jetbrains.annotations.NotNull;
-
 import java.awt.*;
-
-import static java.util.Objects.requireNonNull;
+import org.jetbrains.annotations.NotNull;
 
 public class PreferencesReader {
 
@@ -16,7 +15,10 @@ public class PreferencesReader {
 
     private final ProjectPreferences projectPrefs;
 
-    public PreferencesReader(@NotNull Project project, @NotNull ProjectPreferences projectPrefs, @NotNull ApplicationPreferences appPrefs) {
+    public PreferencesReader(
+            @NotNull Project project,
+            @NotNull ProjectPreferences projectPrefs,
+            @NotNull ApplicationPreferences appPrefs) {
         this.project = requireNonNull(project);
         this.appPrefs = requireNonNull(appPrefs);
         this.projectPrefs = requireNonNull(projectPrefs);
@@ -44,12 +46,14 @@ public class PreferencesReader {
     }
 
     public BackgroundImagePosition backgroundImagePosition() {
-        return projectPrefs.isBackgroundImageInherited() ? appPrefs.getBackgroundImagePosition() : projectPrefs.getBackgroundImagePosition();
+        return projectPrefs.isBackgroundImageInherited()
+                ? appPrefs.getBackgroundImagePosition()
+                : projectPrefs.getBackgroundImagePosition();
     }
 
     public int backgroundImageOpacity() {
-        return projectPrefs.isBackgroundImageInherited() ? appPrefs.getBackgroundImageOpacity() : projectPrefs.getBackgroundImageOpacity();
+        return projectPrefs.isBackgroundImageInherited()
+                ? appPrefs.getBackgroundImageOpacity()
+                : projectPrefs.getBackgroundImageOpacity();
     }
-
-
 }

--- a/src/main/java/com/drinchev/projectlabel/preferences/ProjectPreferences.java
+++ b/src/main/java/com/drinchev/projectlabel/preferences/ProjectPreferences.java
@@ -6,24 +6,18 @@ import com.drinchev.projectlabel.utils.UtilsFont;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-
 import com.intellij.openapi.project.Project;
 import com.intellij.util.xmlb.XmlSerializerUtil;
 import com.intellij.util.xmlb.annotations.OptionTag;
+import java.awt.*;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-
-import java.awt.*;
-import java.util.Objects;
-
-import static java.util.Objects.requireNonNull;
 
 @State(
         name = "ProjectLabel",
         storages = {
-                @Storage("project-label.xml"),
-        }
-)
+            @Storage("project-label.xml"),
+        })
 public class ProjectPreferences implements PersistentStateComponent<ProjectPreferences> {
 
     @OptionTag

--- a/src/main/java/com/drinchev/projectlabel/resources/ui/BackgroundImagePosition.java
+++ b/src/main/java/com/drinchev/projectlabel/resources/ui/BackgroundImagePosition.java
@@ -1,9 +1,8 @@
 package com.drinchev.projectlabel.resources.ui;
 
-import org.jetbrains.annotations.NotNull;
-
 import java.util.Objects;
 import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
 
 public enum BackgroundImagePosition {
     HIDDEN("Hidden"),

--- a/src/main/java/com/drinchev/projectlabel/resources/ui/ColorField.java
+++ b/src/main/java/com/drinchev/projectlabel/resources/ui/ColorField.java
@@ -1,9 +1,8 @@
 package com.drinchev.projectlabel.resources.ui;
 
 import com.drinchev.projectlabel.utils.UtilsColor;
-
-import javax.swing.*;
 import java.awt.*;
+import javax.swing.*;
 
 class ColorField {
 
@@ -37,5 +36,4 @@ class ColorField {
     String getName() {
         return this.name;
     }
-
 }

--- a/src/main/java/com/drinchev/projectlabel/resources/ui/ColorFieldMouseListener.java
+++ b/src/main/java/com/drinchev/projectlabel/resources/ui/ColorFieldMouseListener.java
@@ -1,7 +1,6 @@
 package com.drinchev.projectlabel.resources.ui;
 
 import com.intellij.ui.ColorPicker;
-
 import java.awt.*;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
@@ -20,33 +19,21 @@ public class ColorFieldMouseListener implements MouseListener {
     @Override
     public void mouseClicked(MouseEvent mouseEvent) {
         Color color = ColorPicker.showDialog(
-                this.colorField.getField(),
-                this.colorField.getName(),
-                this.colorField.getColor(),
-                false,
-                null,
-                false
-        );
+                this.colorField.getField(), this.colorField.getName(), this.colorField.getColor(), false, null, false);
         if (color != null) {
             this.colorField.setColor(color);
         }
     }
 
     @Override
-    public void mousePressed(MouseEvent mouseEvent) {
-    }
+    public void mousePressed(MouseEvent mouseEvent) {}
 
     @Override
-    public void mouseReleased(MouseEvent mouseEvent) {
-    }
+    public void mouseReleased(MouseEvent mouseEvent) {}
 
     @Override
-    public void mouseEntered(MouseEvent mouseEvent) {
-    }
+    public void mouseEntered(MouseEvent mouseEvent) {}
 
     @Override
-    public void mouseExited(MouseEvent mouseEvent) {
-
-    }
-
+    public void mouseExited(MouseEvent mouseEvent) {}
 }

--- a/src/main/java/com/drinchev/projectlabel/resources/ui/PluginConfiguration.java
+++ b/src/main/java/com/drinchev/projectlabel/resources/ui/PluginConfiguration.java
@@ -5,10 +5,6 @@ import com.drinchev.projectlabel.utils.UtilsIcon;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.ui.FontComboBox;
 import com.intellij.ui.TitledSeparator;
-import org.jetbrains.annotations.NotNull;
-
-import javax.swing.*;
-import javax.swing.border.Border;
 import java.awt.*;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
@@ -17,10 +13,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
+import javax.swing.*;
+import javax.swing.border.Border;
+import org.jetbrains.annotations.NotNull;
 
 public class PluginConfiguration {
 
-    private final static Logger LOG = Logger.getInstance(PluginConfiguration.class);
+    private static final Logger LOG = Logger.getInstance(PluginConfiguration.class);
 
     private JPanel rootPanel;
     private JTextField textFieldBackgroundColor;
@@ -52,37 +51,53 @@ public class PluginConfiguration {
     private SpinnerNumberModel spinnerFontSizeModel;
     private SpinnerNumberModel spinnerGlobalFontSizeModel;
 
-    private final static Map<BackgroundImagePosition, Icon> LABEL_POSITIONS = Collections.unmodifiableMap(new LinkedHashMap<>() {{ // linked hash map to preserve order
-        put(BackgroundImagePosition.CENTER, UtilsIcon.loadRasterizedIcon("icons/bg_image_pos_center.svg"));
-        put(BackgroundImagePosition.TOP_LEFT, UtilsIcon.loadRasterizedIcon("icons/bg_image_pos_top_left.svg"));
-        put(BackgroundImagePosition.TOP_RIGHT, UtilsIcon.loadRasterizedIcon("icons/bg_image_pos_top_right.svg"));
-        put(BackgroundImagePosition.BOTTOM_RIGHT, UtilsIcon.loadRasterizedIcon("icons/bg_image_pos_bottom_right.svg"));
-        put(BackgroundImagePosition.BOTTOM_LEFT, UtilsIcon.loadRasterizedIcon("icons/bg_image_pos_bottom_left.svg"));
-    }});
+    private static final Map<BackgroundImagePosition, Icon> LABEL_POSITIONS =
+            Collections.unmodifiableMap(new LinkedHashMap<>() {
+                { // linked hash map to preserve order
+                    put(BackgroundImagePosition.CENTER, UtilsIcon.loadRasterizedIcon("icons/bg_image_pos_center.svg"));
+                    put(
+                            BackgroundImagePosition.TOP_LEFT,
+                            UtilsIcon.loadRasterizedIcon("icons/bg_image_pos_top_left.svg"));
+                    put(
+                            BackgroundImagePosition.TOP_RIGHT,
+                            UtilsIcon.loadRasterizedIcon("icons/bg_image_pos_top_right.svg"));
+                    put(
+                            BackgroundImagePosition.BOTTOM_RIGHT,
+                            UtilsIcon.loadRasterizedIcon("icons/bg_image_pos_bottom_right.svg"));
+                    put(
+                            BackgroundImagePosition.BOTTOM_LEFT,
+                            UtilsIcon.loadRasterizedIcon("icons/bg_image_pos_bottom_left.svg"));
+                }
+            });
 
-    private final static Map<BackgroundImagePosition, Icon> DISABLED_LABEL_POSITIONS = Collections.unmodifiableMap(new LinkedHashMap<>() {{ // linked hash map to preserve order
-        put(BackgroundImagePosition.CENTER, UtilsIcon.disabledIcon(LABEL_POSITIONS.get(BackgroundImagePosition.CENTER)));
-        put(BackgroundImagePosition.TOP_LEFT, UtilsIcon.disabledIcon(LABEL_POSITIONS.get(BackgroundImagePosition.TOP_LEFT)));
-        put(BackgroundImagePosition.TOP_RIGHT, UtilsIcon.disabledIcon(LABEL_POSITIONS.get(BackgroundImagePosition.TOP_RIGHT)));
-        put(BackgroundImagePosition.BOTTOM_RIGHT, UtilsIcon.disabledIcon(LABEL_POSITIONS.get(BackgroundImagePosition.BOTTOM_RIGHT)));
-        put(BackgroundImagePosition.BOTTOM_LEFT, UtilsIcon.disabledIcon(LABEL_POSITIONS.get(BackgroundImagePosition.BOTTOM_LEFT)));
-    }});
-
+    private static final Map<BackgroundImagePosition, Icon> DISABLED_LABEL_POSITIONS =
+            Collections.unmodifiableMap(new LinkedHashMap<>() {
+                { // linked hash map to preserve order
+                    put(
+                            BackgroundImagePosition.CENTER,
+                            UtilsIcon.disabledIcon(LABEL_POSITIONS.get(BackgroundImagePosition.CENTER)));
+                    put(
+                            BackgroundImagePosition.TOP_LEFT,
+                            UtilsIcon.disabledIcon(LABEL_POSITIONS.get(BackgroundImagePosition.TOP_LEFT)));
+                    put(
+                            BackgroundImagePosition.TOP_RIGHT,
+                            UtilsIcon.disabledIcon(LABEL_POSITIONS.get(BackgroundImagePosition.TOP_RIGHT)));
+                    put(
+                            BackgroundImagePosition.BOTTOM_RIGHT,
+                            UtilsIcon.disabledIcon(LABEL_POSITIONS.get(BackgroundImagePosition.BOTTOM_RIGHT)));
+                    put(
+                            BackgroundImagePosition.BOTTOM_LEFT,
+                            UtilsIcon.disabledIcon(LABEL_POSITIONS.get(BackgroundImagePosition.BOTTOM_LEFT)));
+                }
+            });
 
     /**
      * Constructor
      */
     public PluginConfiguration() {
-        this.colorFieldTextColor = new ColorField(
-                textFieldTextColor,
-                panelTextColor,
-                "Text Color"
-        );
-        this.colorFieldBackgroundColor = new ColorField(
-                textFieldBackgroundColor,
-                panelBackgroundColor,
-                "Background Color"
-        );
+        this.colorFieldTextColor = new ColorField(textFieldTextColor, panelTextColor, "Text Color");
+        this.colorFieldBackgroundColor =
+                new ColorField(textFieldBackgroundColor, panelBackgroundColor, "Background Color");
         this.spinnerFontSizeModel = new SpinnerNumberModel(0, 0, 36, 1);
         this.spinnerFontSize.setModel(this.spinnerFontSizeModel);
 
@@ -96,7 +111,8 @@ public class PluginConfiguration {
 
         this.editorImageEnabledCheckbox.addActionListener(this::updateBackgroundImageCheckboxDependingStatesAndValues);
 
-        this.editorImageEnabledCheckboxGlobal.addActionListener(this::updateBackgroundImageCheckboxDependingStatesAndValues);
+        this.editorImageEnabledCheckboxGlobal.addActionListener(
+                this::updateBackgroundImageCheckboxDependingStatesAndValues);
 
         this.editorImageBackgroundOpacityModel = new SpinnerNumberModel(15, 0, 100, 1);
         this.editorImageBackgroundOpacity.setModel(this.editorImageBackgroundOpacityModel);
@@ -107,7 +123,9 @@ public class PluginConfiguration {
         Stream.of(this.editorImagePositionComboBox, this.editorImagePositionComboBoxGlobal)
                 .forEach(comboBox -> {
                     comboBox.setRenderer(new LabelWithIconRenderer(comboBox));
-                    comboBox.setModel(new DefaultComboBoxModel<>(LABEL_POSITIONS.keySet().stream().map(BackgroundImagePosition::displayName).toArray(String[]::new)));
+                    comboBox.setModel(new DefaultComboBoxModel<>(LABEL_POSITIONS.keySet().stream()
+                            .map(BackgroundImagePosition::displayName)
+                            .toArray(String[]::new)));
                 });
 
         editorImageInheritCheckbox.addActionListener(this::updateBackgroundImageCheckboxDependingStatesAndValues);
@@ -122,7 +140,9 @@ public class PluginConfiguration {
                 Insets insets = rootPanel.getInsets();
                 Border border = rootPanel.getBorder();
                 Insets borderInsets = border.getBorderInsets(rootPanel);
-                Dimension preferredSize = new Dimension(rootPanel.getWidth() - (insets.left + insets.right + borderInsets.left + borderInsets.right), -1);
+                Dimension preferredSize = new Dimension(
+                        rootPanel.getWidth() - (insets.left + insets.right + borderInsets.left + borderInsets.right),
+                        -1);
 
                 globalPreferencesSectionTitle.setPreferredSize(preferredSize);
                 projectPreferencesSectionTitle.setPreferredSize(preferredSize);
@@ -135,10 +155,7 @@ public class PluginConfiguration {
         if (inherited) {
             copyFontValuesFromGlobalToProject();
         }
-        Stream.of(
-                this.spinnerFontSize,
-                this.fontComboBoxFont
-        ).forEach(component -> component.setEnabled(!inherited));
+        Stream.of(this.spinnerFontSize, this.fontComboBoxFont).forEach(component -> component.setEnabled(!inherited));
     }
 
     private void copyFontValuesFromGlobalToProject() {
@@ -152,10 +169,8 @@ public class PluginConfiguration {
         // global
         this.editorImageEnabledCheckboxGlobal.setEnabled(true);
         final boolean globallyEnabled = this.editorImageEnabledCheckboxGlobal.isSelected();
-        Stream.of(
-                this.editorImagePositionComboBoxGlobal,
-                this.editorImageBackgroundOpacityGlobal
-        ).forEach(component -> component.setEnabled(globallyEnabled));
+        Stream.of(this.editorImagePositionComboBoxGlobal, this.editorImageBackgroundOpacityGlobal)
+                .forEach(component -> component.setEnabled(globallyEnabled));
 
         // project
         final boolean inherited = this.editorImageInheritCheckbox.isSelected();
@@ -165,10 +180,8 @@ public class PluginConfiguration {
         this.editorImageEnabledCheckbox.setEnabled(!inherited);
 
         final boolean projectEnabled = this.editorImageEnabledCheckbox.isSelected() && !inherited;
-        Stream.of(
-                this.editorImagePositionComboBox,
-                this.editorImageBackgroundOpacity
-        ).forEach(component -> component.setEnabled(projectEnabled));
+        Stream.of(this.editorImagePositionComboBox, this.editorImageBackgroundOpacity)
+                .forEach(component -> component.setEnabled(projectEnabled));
     }
 
     private void copyBackgroundImageValuesFromGlobalToProject() {
@@ -180,8 +193,8 @@ public class PluginConfiguration {
     }
 
     public void initStates() {
-            updateFontCheckboxDependingStatesAndValues(null);
-            updateBackgroundImageCheckboxDependingStatesAndValues(null);
+        updateFontCheckboxDependingStatesAndValues(null);
+        updateBackgroundImageCheckboxDependingStatesAndValues(null);
     }
 
     public void setTextColor(Color color) {
@@ -201,7 +214,9 @@ public class PluginConfiguration {
     }
 
     public int getFontSize() {
-        return this.checkBoxInheritFont.isSelected() ? -1 : this.spinnerFontSizeModel.getNumber().intValue();
+        return this.checkBoxInheritFont.isSelected()
+                ? -1
+                : this.spinnerFontSizeModel.getNumber().intValue();
     }
 
     public void setFontSize(int fontSize) {
@@ -259,13 +274,21 @@ public class PluginConfiguration {
         Objects.requireNonNull(globalPrefs);
         if (globalPrefs.position() == BackgroundImagePosition.HIDDEN) {
             editorImageEnabledCheckboxGlobal.setSelected(false);
-            Stream.of(this.editorImagePositionComboBoxGlobal, this.editorImageBackgroundOpacityGlobal, this.editorImageEnabledCheckboxGlobal)
+            Stream.of(
+                            this.editorImagePositionComboBoxGlobal,
+                            this.editorImageBackgroundOpacityGlobal,
+                            this.editorImageEnabledCheckboxGlobal)
                     .forEach(component -> component.setEnabled(false));
         } else {
             editorImageEnabledCheckboxGlobal.setSelected(true);
-            Stream.of(this.editorImagePositionComboBoxGlobal, this.editorImageBackgroundOpacityGlobal, this.editorImageEnabledCheckboxGlobal)
+            Stream.of(
+                            this.editorImagePositionComboBoxGlobal,
+                            this.editorImageBackgroundOpacityGlobal,
+                            this.editorImageEnabledCheckboxGlobal)
                     .forEach(component -> component.setEnabled(true));
-            editorImagePositionComboBoxGlobal.getModel().setSelectedItem(globalPrefs.position().displayName());
+            editorImagePositionComboBoxGlobal
+                    .getModel()
+                    .setSelectedItem(globalPrefs.position().displayName());
             editorImageBackgroundOpacityModelGlobal.setValue(globalPrefs.opacity());
         }
         if (projPrefs == null) {
@@ -273,7 +296,9 @@ public class PluginConfiguration {
         } else {
             editorImageInheritCheckbox.setSelected(false);
             editorImageEnabledCheckbox.setSelected(projPrefs.position() != BackgroundImagePosition.HIDDEN);
-            editorImagePositionComboBox.getModel().setSelectedItem(projPrefs.position().displayName());
+            editorImagePositionComboBox
+                    .getModel()
+                    .setSelectedItem(projPrefs.position().displayName());
             editorImageBackgroundOpacityModel.setValue(projPrefs.opacity());
         }
         updateBackgroundImageCheckboxDependingStatesAndValues(null);
@@ -286,14 +311,16 @@ public class PluginConfiguration {
         int opacity = editorImageBackgroundOpacityModel.getNumber().intValue();
         String positionString = (String) editorImagePositionComboBox.getSelectedItem();
         BackgroundImagePosition position = BackgroundImagePosition.findByDisplayName(positionString);
-        return new BackgroundImagePrefs(opacity, editorImageEnabledCheckbox.isSelected() ? position : BackgroundImagePosition.HIDDEN);
+        return new BackgroundImagePrefs(
+                opacity, editorImageEnabledCheckbox.isSelected() ? position : BackgroundImagePosition.HIDDEN);
     }
 
     public BackgroundImagePrefs getGlobalBackgroundImagePrefs() {
         int opacity = editorImageBackgroundOpacityModelGlobal.getNumber().intValue();
         String positionString = (String) editorImagePositionComboBoxGlobal.getSelectedItem();
         BackgroundImagePosition position = BackgroundImagePosition.findByDisplayName(positionString);
-        return new BackgroundImagePrefs(opacity, editorImageEnabledCheckboxGlobal.isSelected() ? position : BackgroundImagePosition.HIDDEN);
+        return new BackgroundImagePrefs(
+                opacity, editorImageEnabledCheckboxGlobal.isSelected() ? position : BackgroundImagePosition.HIDDEN);
     }
 
     /**
@@ -312,7 +339,8 @@ public class PluginConfiguration {
         }
 
         @Override
-        public Component getListCellRendererComponent(JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
+        public Component getListCellRendererComponent(
+                JList<?> list, Object value, int index, boolean isSelected, boolean cellHasFocus) {
             JLabel label = (JLabel) super.getListCellRendererComponent(list, value, index, isSelected, cellHasFocus);
 
             String positionDisplayName = (String) value;

--- a/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelAWTDebugRenderer.java
+++ b/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelAWTDebugRenderer.java
@@ -6,8 +6,7 @@ public class ProjectLabelAWTDebugRenderer {
 
     public static final boolean DEBUG = false;
 
-    private ProjectLabelAWTDebugRenderer() {
-    }
+    private ProjectLabelAWTDebugRenderer() {}
 
     public static void drawDebugRect(Graphics2D g2d, int x, int y, int width, int height, Color color) {
         if (!DEBUG) {

--- a/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelAWTRenderer.java
+++ b/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelAWTRenderer.java
@@ -1,35 +1,31 @@
 package com.drinchev.projectlabel.resources.ui;
 
+import static java.util.Map.entry;
+import static java.util.Map.ofEntries;
+import static java.util.Objects.requireNonNull;
+
 import com.drinchev.projectlabel.preferences.PreferencesReader;
 import com.drinchev.projectlabel.utils.UtilsFont;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.ui.JBColor;
 import com.intellij.ui.scale.JBUIScale;
 import com.intellij.util.ui.ImageUtil;
-import org.jetbrains.annotations.NotNull;
-
 import java.awt.*;
 import java.awt.font.FontRenderContext;
 import java.awt.font.TextAttribute;
 import java.awt.image.BufferedImage;
-
-import static java.util.Map.entry;
-import static java.util.Map.ofEntries;
-import static java.util.Objects.requireNonNull;
+import org.jetbrains.annotations.NotNull;
 
 public class ProjectLabelAWTRenderer {
 
-    private final static Logger LOG = Logger.getInstance(ProjectLabelAWTRenderer.class);
+    private static final Logger LOG = Logger.getInstance(ProjectLabelAWTRenderer.class);
 
-    public static final RenderingHints RENDERING_HINTS = new RenderingHints(
-            ofEntries(
-                    entry(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY),
-                    entry(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON),
-                    entry(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY),
-                    entry(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON),
-                    entry(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON)
-            )
-    );
+    public static final RenderingHints RENDERING_HINTS = new RenderingHints(ofEntries(
+            entry(RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY),
+            entry(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON),
+            entry(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY),
+            entry(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON),
+            entry(RenderingHints.KEY_FRACTIONALMETRICS, RenderingHints.VALUE_FRACTIONALMETRICS_ON)));
 
     public static final int HORIZONTAL_PADDING = 8;
     public static final int VERTICAL_PADDING = 2;
@@ -38,18 +34,19 @@ public class ProjectLabelAWTRenderer {
 
     private final PreferencesReader preferences;
 
-
     public ProjectLabelAWTRenderer(@NotNull PreferencesReader preferences) {
         this.preferences = requireNonNull(preferences);
     }
 
     public static BufferedImage renderImageWithInsets(BufferedImage source, Insets border) {
-        final Dimension targetArea = new Dimension(source.getWidth() + border.left + border.right, source.getHeight() + border.top + border.bottom);
+        final Dimension targetArea = new Dimension(
+                source.getWidth() + border.left + border.right, source.getHeight() + border.top + border.bottom);
 
         // make sure to transfer image configuration (to account for high DPI)
         Graphics2D origGraphics = source.createGraphics();
         GraphicsConfiguration gfxConfig = origGraphics.getDeviceConfiguration();
-        BufferedImage bufferedImage = gfxConfig.createCompatibleImage(targetArea.width, targetArea.height, source.getTransparency());
+        BufferedImage bufferedImage =
+                gfxConfig.createCompatibleImage(targetArea.width, targetArea.height, source.getTransparency());
         origGraphics.dispose();
 
         Graphics2D g2d = bufferedImage.createGraphics();
@@ -86,7 +83,7 @@ public class ProjectLabelAWTRenderer {
 
         // background
         graphics.setColor(preferences.backgroundColor());
-        graphics.fillRoundRect(0, 0,  width, height, arcs.width, arcs.height);
+        graphics.fillRoundRect(0, 0, width, height, arcs.width, arcs.height);
 
         // label
         graphics.setColor(preferences.textColor());
@@ -95,14 +92,14 @@ public class ProjectLabelAWTRenderer {
         graphics.drawString(
                 preferences.label(),
                 (width - labelWidth) / 2,
-                (height - metrics.getHeight()) / 2 + metrics.getAscent()
-        );
+                (height - metrics.getHeight()) / 2 + metrics.getAscent());
         graphics.dispose();
         return bufferedImage;
     }
 
     private Dimension zoomed(double zoomFactor, Dimension dimension) {
-        return new Dimension((int) Math.round(zoomFactor * dimension.getWidth()), (int) Math.round(zoomFactor * dimension.getHeight()));
+        return new Dimension((int) Math.round(zoomFactor * dimension.getWidth()), (int)
+                Math.round(zoomFactor * dimension.getHeight()));
     }
 
     public Dimension getPreferredSize() {
@@ -133,14 +130,12 @@ public class ProjectLabelAWTRenderer {
     }
 
     private Dimension getTextDimensions(Font font, String label) {
-            FontRenderContext renderContext = new FontRenderContext(font.getTransform(), true, true);
+        FontRenderContext renderContext = new FontRenderContext(font.getTransform(), true, true);
 
-        Dimension textDimension = new Dimension(
-                (int) (font.getStringBounds(label, renderContext).getWidth()),
-                (int) (font.getStringBounds(label, renderContext).getHeight())
-        );
+        Dimension textDimension =
+                new Dimension((int) (font.getStringBounds(label, renderContext).getWidth()), (int)
+                        (font.getStringBounds(label, renderContext).getHeight()));
 
         return textDimension;
     }
-
 }

--- a/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelBackgroundImage.java
+++ b/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelBackgroundImage.java
@@ -1,5 +1,7 @@
 package com.drinchev.projectlabel.resources.ui;
 
+import static java.util.Objects.requireNonNull;
+
 import com.drinchev.projectlabel.preferences.ApplicationPreferences;
 import com.drinchev.projectlabel.preferences.PreferencesReader;
 import com.drinchev.projectlabel.preferences.ProjectPreferences;
@@ -11,10 +13,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.WindowManager;
 import com.intellij.openapi.wm.impl.IdeBackgroundUtil;
 import com.intellij.util.ui.JBUI;
-import org.jetbrains.annotations.NotNull;
-
-import javax.imageio.ImageIO;
-import javax.swing.*;
 import java.awt.*;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
@@ -24,9 +22,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Optional;
-
-import static java.util.Objects.requireNonNull;
-
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import org.jetbrains.annotations.NotNull;
 
 @Service(Level.PROJECT)
 public class ProjectLabelBackgroundImage {
@@ -47,7 +45,7 @@ public class ProjectLabelBackgroundImage {
 
     public static final int BORDER_Y_MARGIN = 28;
 
-    private final static Logger LOG = Logger.getInstance(ProjectLabelStatusBarWidget.class);
+    private static final Logger LOG = Logger.getInstance(ProjectLabelStatusBarWidget.class);
 
     private BufferedImage bufferedImage;
 
@@ -59,7 +57,8 @@ public class ProjectLabelBackgroundImage {
 
     public ProjectLabelBackgroundImage(@NotNull Project project) {
         this.project = requireNonNull(project);
-        this.preferences = new PreferencesReader(project, ProjectPreferences.getInstance(project), ApplicationPreferences.getInstance());
+        this.preferences = new PreferencesReader(
+                project, ProjectPreferences.getInstance(project), ApplicationPreferences.getInstance());
 
         var window = WindowManager.getInstance().getFrame(project);
         if (window == null) {
@@ -95,7 +94,11 @@ public class ProjectLabelBackgroundImage {
     private void setImageToIDE() {
         PropertiesComponent prop = projectLevelPropertiesComponent();
         String opacity = String.valueOf(preferences.backgroundImageOpacity());
-        String imageProp = String.format("%s,%s,plain,%s", resultingImage, opacity, preferences.backgroundImagePosition().name().toLowerCase());
+        String imageProp = String.format(
+                "%s,%s,plain,%s",
+                resultingImage,
+                opacity,
+                preferences.backgroundImagePosition().name().toLowerCase());
         String prev_editor = prop.getValue(IdeBackgroundUtil.EDITOR_PROP);
         prop.setValue(IdeBackgroundUtil.EDITOR_PROP, imageProp);
         String prev_frame = prop.getValue(IdeBackgroundUtil.FRAME_PROP);
@@ -160,7 +163,8 @@ public class ProjectLabelBackgroundImage {
                 BufferedImage rawLabelImage = renderer.renderLabelAsImage(preferredImageDimension, new Dimension(0, 0));
 
                 @SuppressWarnings("UseDPIAwareInsets")
-                final Insets insets = new Insets(JBUI.scale(BORDER_Y_MARGIN) + BORDER_Y_PADDING,
+                final Insets insets = new Insets(
+                        JBUI.scale(BORDER_Y_MARGIN) + BORDER_Y_PADDING,
                         JBUI.scale(BORDER_X_MARGIN) + BORDER_X_PADDING,
                         JBUI.scale(BORDER_Y_MARGIN) + BORDER_Y_PADDING,
                         JBUI.scale(BORDER_X_MARGIN) + BORDER_X_PADDING);
@@ -181,7 +185,8 @@ public class ProjectLabelBackgroundImage {
         LOG.debug("Preferred image ratio: " + preferredImageRatio);
 
         final int targetHeight = targetHeight();
-        final int targetWidth = (int) Math.round(targetHeight / preferredImageRatio.getHeight() * preferredImageRatio.getWidth());
+        final int targetWidth =
+                (int) Math.round(targetHeight / preferredImageRatio.getHeight() * preferredImageRatio.getWidth());
 
         final int maxWidth = projectFrame()
                 .map(JFrame::getWidth)
@@ -189,7 +194,8 @@ public class ProjectLabelBackgroundImage {
                 .orElse(targetWidth);
 
         if (targetWidth > maxWidth) {
-            int heightMatchingMaxWidth = (int) Math.round(maxWidth / preferredImageRatio.getWidth() * preferredImageRatio.getHeight());
+            int heightMatchingMaxWidth =
+                    (int) Math.round(maxWidth / preferredImageRatio.getWidth() * preferredImageRatio.getHeight());
             LOG.debug("Target image width is too big. Resizing to " + maxWidth + "x" + heightMatchingMaxWidth);
             return new Dimension(maxWidth, heightMatchingMaxWidth);
         } else {
@@ -204,7 +210,8 @@ public class ProjectLabelBackgroundImage {
             LOG.warn("Could not get project frame for project " + project.getName() + ". Using default height.");
             return DEFAULT_HEIGHT;
         }
-        LOG.info("Project frame size: " + projectFrame.get().getWidth() + "x" + projectFrame.get().getHeight());
+        LOG.info("Project frame size: " + projectFrame.get().getWidth() + "x"
+                + projectFrame.get().getHeight());
         int partialHeight = (int) Math.round(projectFrame.get().getHeight() * TARGET_HEIGHT_PERCENTAGE);
         int resultingHeight = Math.max(partialHeight, MIN_HEIGHT);
         LOG.info("Background image height: " + resultingHeight);

--- a/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelStatusBarWidget.java
+++ b/src/main/java/com/drinchev/projectlabel/resources/ui/ProjectLabelStatusBarWidget.java
@@ -1,5 +1,7 @@
 package com.drinchev.projectlabel.resources.ui;
 
+import static java.util.Objects.requireNonNull;
+
 import com.drinchev.projectlabel.preferences.PreferencesReader;
 import com.drinchev.projectlabel.utils.UtilsUI;
 import com.intellij.openapi.diagnostic.Logger;
@@ -10,18 +12,14 @@ import com.intellij.openapi.wm.StatusBar;
 import com.intellij.ui.scale.JBUIScale;
 import com.intellij.util.ui.JBUI;
 import com.intellij.util.ui.UIUtil;
+import java.awt.*;
+import javax.swing.*;
 import org.jetbrains.annotations.NonNls;
 import org.jetbrains.annotations.NotNull;
 
-import javax.swing.*;
-import java.awt.*;
-
-import static java.util.Objects.requireNonNull;
-
-
 public class ProjectLabelStatusBarWidget extends JButton implements CustomStatusBarWidget {
 
-    private final static Logger LOG = Logger.getInstance(ProjectLabelStatusBarWidget.class);
+    private static final Logger LOG = Logger.getInstance(ProjectLabelStatusBarWidget.class);
 
     @NonNls
     public static final String WIDGET_ID = "ProjectLabelWidget";
@@ -70,12 +68,10 @@ public class ProjectLabelStatusBarWidget extends JButton implements CustomStatus
     }
 
     @Override
-    public void dispose() {
-    }
+    public void dispose() {}
 
     @Override
-    public void install(@NotNull StatusBar statusBar) {
-    }
+    public void install(@NotNull StatusBar statusBar) {}
 
     @Override
     @NotNull
@@ -124,6 +120,4 @@ public class ProjectLabelStatusBarWidget extends JButton implements CustomStatus
     public Dimension getMaximumSize() {
         return getPreferredSize();
     }
-
-
 }

--- a/src/main/java/com/drinchev/projectlabel/utils/UtilsColor.java
+++ b/src/main/java/com/drinchev/projectlabel/utils/UtilsColor.java
@@ -24,5 +24,4 @@ public class UtilsColor {
     public static Boolean isEqual(Color colorA, Color colorB) {
         return colorA.getRGB() == colorB.getRGB();
     }
-
 }

--- a/src/main/java/com/drinchev/projectlabel/utils/UtilsFont.java
+++ b/src/main/java/com/drinchev/projectlabel/utils/UtilsFont.java
@@ -1,7 +1,6 @@
 package com.drinchev.projectlabel.utils;
 
 import com.intellij.util.ui.JBFont;
-
 import java.awt.*;
 import java.awt.font.TextAttribute;
 import java.util.HashMap;
@@ -51,5 +50,4 @@ public class UtilsFont {
         }
         throw new IllegalStateException("Unable to determine the status bar font size");
     }
-
 }

--- a/src/main/java/com/drinchev/projectlabel/utils/UtilsIcon.java
+++ b/src/main/java/com/drinchev/projectlabel/utils/UtilsIcon.java
@@ -1,13 +1,11 @@
 package com.drinchev.projectlabel.utils;
 
 import com.intellij.openapi.util.IconLoader;
-
 import javax.swing.*;
 
 public final class UtilsIcon {
 
-    private UtilsIcon() {
-    }
+    private UtilsIcon() {}
 
     public static Icon loadRasterizedIcon(String path) {
         return IconLoader.getIcon(path, UtilsIcon.class);
@@ -16,5 +14,4 @@ public final class UtilsIcon {
     public static Icon disabledIcon(Icon icon) {
         return IconLoader.getDisabledIcon(icon);
     }
-
 }

--- a/src/main/java/com/drinchev/projectlabel/utils/UtilsUI.java
+++ b/src/main/java/com/drinchev/projectlabel/utils/UtilsUI.java
@@ -7,5 +7,4 @@ public class UtilsUI {
     public static Boolean isNewUI() {
         return Registry.is("ide.experimental.ui");
     }
-
 }


### PR DESCRIPTION
I noticed there was no code style configured in the project, so I went ahead and added that.

I went with the [spotless gradle plugin](https://github.com/diffplug/spotless/tree/main/plugin-gradle) because I think it's outstanding (and yes, I'm a contributor 😉, so I might be biased).

The [palantir-java-format](https://github.com/palantir/palantir-java-format) seems to be closest to what we currently have, so I configured that, but of course, feel free to change that if you'd rather use Google's java format or something else entirely.

I have not applied the actual formatting to the code yet, since that only makes sense once we've agreed on a style.

For development, there are 3 options to work with that code style:
1. Use `gradlew spotlessCheck` or `gradlew spotlessApply` directly.
2. Use the [spotless intellij plugin](https://plugins.jetbrains.com/plugin/18321-spotless-gradle)
3. Use the [palantir intellij plugin](https://plugins.jetbrains.com/plugin/13180-palantir-java-format)

(Myself, I usually work with a mixture of 1. and 2.)

